### PR TITLE
Add setuptools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ ProtonVPN-CLI is a full rewrite of the [bash protonvpn-cli](https://github.com/P
 
 On Fedora/CentOS/RHEL:
 
-`sudo dnf install -y openvpn dialog python3-pip`
+`sudo dnf install -y openvpn dialog python3-pip python3-setuptools`
 
 `sudo pip3 install protonvpn-cli`
 
 On Debian/Ubuntu/Linux Mint and derivatives:
 
-`sudo apt install -y openvpn dialog python3-pip`
+`sudo apt install -y openvpn dialog python3-pip python3-setuptools`
 
 `sudo pip3 install protonvpn-cli`
 
 On SUSE:
 
-`sudo zypper in -y openvpn dialog python3-pip`
+`sudo zypper in -y openvpn dialog python3-pip python3-setuptools`
 
 `sudo pip3 install protonvpn-cli`
 
 On Arch/Manjaro:
 
-`sudo pacman -S openvpn dialog python-pip`
+`sudo pacman -S openvpn dialog python-pip python-setuptools`
 
 `sudo pip3 install protonvpn-cli`
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -43,12 +43,12 @@ This document provides an extensive guide on how to install and use ProtonVPN-CL
 
 Depending on your distribution, run the appropriate following command to install the necessary dependencies
 
-| **Distro**                              | **Command**                                     |
-|:----------------------------------------|:------------------------------------------------|
-|Fedora/CentOS/RHEL                       | `sudo dnf install -y openvpn dialog python3-pip`|
-|Ubuntu/Linux Mint/Debian and derivatives | `sudo apt install -y openvpn dialog python3-pip`|
-|OpenSUSE/SLES                            | `sudo zypper in -y openvpn dialog python3-pip`  |
-|Arch Linux/Manjaro                       | `sudo pacman -S openvpn dialog python-pip`      |
+| **Distro**                              | **Command**                                                        |
+|:----------------------------------------|:------------------------------------------------                   |
+|Fedora/CentOS/RHEL                       | `sudo dnf install -y openvpn dialog python3-pip python3-setuptools`|
+|Ubuntu/Linux Mint/Debian and derivatives | `sudo apt install -y openvpn dialog python3-pip python3-setuptools`|
+|OpenSUSE/SLES                            | `sudo zypper in -y openvpn dialog python3-pip python3-setuptools`  |
+|Arch Linux/Manjaro                       | `sudo pacman -S openvpn dialog python-pip python-setuptools`       |
 
 ### Installing ProtonVPN-CLI
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -80,7 +80,7 @@ Bye Bye 😔
 
 1. Installing dependencies
 
-   To install ProtonVPN-CLI's dependencies, open a terminal and type `sudo apt install -y dialog openvpn python3-pip` and confirm with Enter. Wait for the installation to finish
+   To install ProtonVPN-CLI's dependencies, open a terminal and type `sudo apt install -y dialog openvpn python3-pip python3-setuptools` and confirm with Enter. Wait for the installation to finish
 
 2. Installing ProtonVPN-CLI
 


### PR DESCRIPTION
Needed because the python dependencies docopt and pythondialog don't provide wheel files.