### PR TITLE
Various small fixes and improvements

### DIFF
--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -77,7 +77,6 @@ def main():
 
 def cli():
     """Run user's input command."""
-    args = docopt(__doc__, version=VERSION)
 
     # Initial log values
     change_file_owner(os.path.join(CONFIG_DIR, "pvpn-cli.log"))
@@ -85,9 +84,11 @@ def cli():
     logger.debug("### NEW PROCESS STARTED ###")
     logger.debug("###########################")
     logger.debug(sys.argv)
-    logger.debug("Arguments\n{0}".format(args))
     logger.debug("USER: {0}".format(USER))
     logger.debug("CONFIG_DIR: {0}".format(CONFIG_DIR))
+
+    args = docopt(__doc__, version="ProtonVPN-CLI v{0}".format(VERSION))
+    logger.debug("Arguments\n{0}".format(str(args).replace("\n", "")))
 
     # Parse arguments
     if args.get("init"):

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -246,7 +246,6 @@ def direct(user_input, protocol=None):
         tor = user_server.group(5)
         servername = "{0}#{1}".format(country_code, number) +\
                      "{0}".format('-' + tor if tor is not None else '')
-        print(servername)
     elif re_long.search(user_input):
         user_server = re_long.search(user_input)
         country_code = user_server.group(3)
@@ -256,7 +255,6 @@ def direct(user_input, protocol=None):
         servername = "{0}-{1}#{2}".format(country_code,
                                           country_code2, number) + \
                      "{0}".format('-' + tor if tor is not None else '')
-        servername = (servername)
     else:
         print(
             "[!] '{0}' is not a valid servername\n".format(user_input),

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -12,8 +12,8 @@ import datetime
 import zlib
 # External Libraries
 from dialog import Dialog
-from .logger import logger
 # protonvpn-cli Functions
+from .logger import logger
 from .utils import (
     check_init, pull_server_data, is_connected,
     get_servers, get_server_value, get_config_value,

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -11,6 +11,7 @@ import getpass
 import random
 # External Libraries
 import requests
+# ProtonVPN-CLI functions
 from .logger import logger
 # Constants
 from .constants import (


### PR DESCRIPTION
* Moving logger imports under the correct comment
* Flatten logging of arguments for better log file readability
* Move docopt parsing below initial logging to see what the user typed in the command line in case the syntax is wrong
* Improve Version printout (`2.x.x` -> `ProtonVPN-CLI v2.x.x`)
* Remove unnecessary printout that I used for debugging and forgot to remove
* Remove useless variable definition that shouldn't be in there to begin with