### PR TITLE
Fix #37: Allow LAN access with Kill Switch enabled

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -285,7 +285,13 @@ It works by replacing your existing iptables rules with custom rules that only a
 
 **Enabling Kill Switch**
 
-To enable Kill Switch, open the configuration menu with `protonvpn configure`, then select `5` for Kill Switch and confirm the activation with `y`. On the next connection Kill Switch will be enabled.
+To enable Kill Switch, open the configuration menu with `protonvpn configure`, then select `5` for Kill Switch and confirm the activation with either `1` or `2`, depending on your preference.
+
+`1` will block access from your directly connected network (e.g. public WiFi) and is recommended for laptops that may connect to untrusted networks.
+
+`2` will allow access from your directly connected network and is for computers that don't leave a secure and trusted LAN, like your home network.
+
+On the next connection Kill Switch will be enabled.
 
 *Note: Kill Switch only activates on unexpected connection drops. It will not persist through reboots and not activate when calling `protonvpn disconnect`. To simulate the Kill Switch, kill the OpenVPN process while connected with `sudo pkill openvpn`.*
 

--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -324,7 +324,7 @@ def configure_cli():
             set_dns_protection()
             break
         elif user_choice == "5":
-            set_killswitch(write=True)
+            set_killswitch()
             break
         elif user_choice == "6":
             set_split_tunnel()
@@ -536,25 +536,47 @@ def set_dns_protection():
     print("DNS Management updated.")
 
 
-def set_killswitch(write=False):
+def set_killswitch():
     """Enable or disable the Kill Switch."""
 
-    print(
-        "The Kill Switch will block all network traffic\n"
-        "if the VPN connection drops unexpectedly."
-    )
-    print()
-    user_choice = input("Enable VPN Kill Switch? [y/N]: ")
-
-    if user_choice.strip().lower() == "y":
-        killswitch = 1
-    else:
-        killswitch = 0
-
-    if write:
-        set_config_value("USER", "killswitch", killswitch)
+    while True:
         print()
-        print("Kill Switch configuration updated.")
+        print(
+            "The Kill Switch will block all network traffic\n"
+            "if the VPN connection drops unexpectedly.\n"
+            "\n"
+            "Please note that the Kill Switch assumes only one network interface being active.\n" # noqa
+            "\n"
+            "1) Enable Kill Switch (Block access to/from LAN)\n"
+            "2) Enable Kill Switch (Allow access to/from LAN)\n"
+            "3) Disable Kill Switch"
+        )
+        print()
+        user_choice = input(
+                "Please enter your choice or leave empty to quit: "
+        )
+        user_choice = user_choice.lower().strip()
+        if user_choice == "1":
+            killswitch = 1
+            break
+        elif user_choice == "2":
+            killswitch = 2
+            break
+        elif user_choice == "3":
+            killswitch = 0
+            break
+        elif user_choice == "":
+            print("Quitting configuration.")
+            sys.exit(0)
+        else:
+            print(
+                "[!] Invalid choice. Please enter the number of your choice.\n"
+            )
+            time.sleep(0.5)
+
+    set_config_value("USER", "killswitch", killswitch)
+    print()
+    print("Kill Switch configuration updated.")
 
 
 def set_split_tunnel():

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -167,6 +167,18 @@ def get_fastest_server(server_pool):
     return fastest_server
 
 
+def get_default_nic():
+    """Find and return the default network interface"""
+    default_route = subprocess.run(
+        "ip route show | grep default",
+        stdout=subprocess.PIPE, shell=True
+    )
+
+    # Get the default nic from ip route show output
+    default_nic = default_route.stdout.decode().strip().split()[4]
+    return default_nic
+
+
 def is_connected():
     """Check if a VPN connection already exists."""
     ovpn_processes = subprocess.run(["pgrep", "openvpn"],


### PR DESCRIPTION
This allows a computer to still be reachable (and reach other computers) over the local network.

Before merging this, please thoroughly check if you (or someone else on the team) see anything wrong with how it's done and if this can lead to potential leaks in cases the Kill Switch should protect the traffic.