### PR TITLE
Fix API used by check_update()

### DIFF
--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -347,7 +347,7 @@ def check_update():
         """Return the latest version from pypi"""
         logger.debug("Calling pypi API")
         try:
-            r = requests.get("https://test.pypi.org/pypi/protonvpn-cli/json")
+            r = requests.get("https://pypi.org/pypi/protonvpn-cli/json")
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.ConnectTimeout):
             logger.debug("Couldn't connect to pypi API")
@@ -408,7 +408,7 @@ def check_update():
                 [str(x) for x in latest_version])
                 ) +
             "is available.\n" +
-            "Follow the Update instructions on " +
+            "Follow the Update instructions on\n" +
             "https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md#updating-protonvpn-cli" # noqa
         )
 


### PR DESCRIPTION
I missed changing back the API URL to the "production" PyPI page after testing. I've added the latest version and will add the next version to the test page so users still get the update notification.