### PR TITLE
Fix false positives of openvpn process detection

### DIFF
--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -191,7 +191,7 @@ def get_default_nic():
 
 def is_connected():
     """Check if a VPN connection already exists."""
-    ovpn_processes = subprocess.run(["pgrep", "openvpn"],
+    ovpn_processes = subprocess.run(["pgrep", "--exact", "openvpn"],
                                     stdout=subprocess.PIPE)
     ovpn_processes = ovpn_processes.stdout.decode("utf-8").split()
 


### PR DESCRIPTION
On systems using NetworkManager, there's [nm-openvpn-auth] process
running. The present test for openvpn matches such a process and
fails to connect. Adding --exact fixes the problem as it matches
only "openvpn" processes (exactly).