### PR TITLE
Add ExecStop to systemd service example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -438,6 +438,7 @@ Systemd is the current init system of most major Linux distributions. This guide
    [Service]
    Type=forking
    ExecStart=/usr/local/bin/protonvpn connect -f
+   ExecStop=/usr/local/bin/protonvpn disconnect
    Environment=PVPN_WAIT=300
    Environment=PVPN_DEBUG=1
    Environment=SUDO_USER=user


### PR DESCRIPTION
This is required because systemd will kill the process unceremoniously without it. This will cause the kill switch to activate (if enabled) rendering subsequent connection attempts impossible.

Risk: low